### PR TITLE
fix: remove null optional elements before jsonencode is called SKIP U…

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -5,6 +5,7 @@ An end-to-end example that does the following:
 - Create a new resource group if one is not passed in.
 - Create Key Protect instance with root key.
 - Create a new ICD Enterprise database instance with BYOK encryption.
+- Set 250 max connection for ICD Enterprise database instance.
 - Create service credentials for the database instance.
 - Create a Virtual Private Cloud (VPC).
 - Create Context Based Restriction (CBR) to only allow Enterprise DB to be accessible from the VPC.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -81,6 +81,9 @@ module "enterprise_db" {
   resource_tags              = var.resource_tags
   service_credential_names   = var.service_credential_names
   access_tags                = var.access_tags
+  configuration = {
+    max_connections = 250
+  }
   cbr_rules = [
     {
       description      = "${var.prefix}-edb access only from vpc"

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ resource "ibm_database" "enterprise_db" {
   tags                                 = var.resource_tags
   adminpassword                        = var.admin_pass
   service_endpoints                    = var.service_endpoints
+  # remove elements with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
   configuration                        = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
   key_protect_key                      = var.kms_key_crn
   backup_encryption_key_crn            = local.backup_encryption_key_crn

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "ibm_database" "enterprise_db" {
   tags                                 = var.resource_tags
   adminpassword                        = var.admin_pass
   service_endpoints                    = var.service_endpoints
-  configuration                        = var.configuration != null ? jsonencode(var.configuration) : null
+  configuration                        = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
   key_protect_key                      = var.kms_key_crn
   backup_encryption_key_crn            = local.backup_encryption_key_crn
   point_in_time_recovery_deployment_id = var.pitr_id

--- a/main.tf
+++ b/main.tf
@@ -48,19 +48,19 @@ resource "time_sleep" "wait_for_authorization_policy" {
 
 # Create edb database
 resource "ibm_database" "enterprise_db" {
-  depends_on                           = [ibm_iam_authorization_policy.kms_policy]
-  resource_group_id                    = var.resource_group_id
-  name                                 = var.name
-  service                              = "databases-for-enterprisedb"
-  location                             = var.region
-  plan                                 = "standard" # Only standard plan is available for edb
-  backup_id                            = var.backup_crn
-  plan_validation                      = var.plan_validation
-  remote_leader_id                     = var.remote_leader_crn
-  version                              = var.edb_version
-  tags                                 = var.resource_tags
-  adminpassword                        = var.admin_pass
-  service_endpoints                    = var.service_endpoints
+  depends_on        = [ibm_iam_authorization_policy.kms_policy]
+  resource_group_id = var.resource_group_id
+  name              = var.name
+  service           = "databases-for-enterprisedb"
+  location          = var.region
+  plan              = "standard" # Only standard plan is available for edb
+  backup_id         = var.backup_crn
+  plan_validation   = var.plan_validation
+  remote_leader_id  = var.remote_leader_crn
+  version           = var.edb_version
+  tags              = var.resource_tags
+  adminpassword     = var.admin_pass
+  service_endpoints = var.service_endpoints
   # remove elements with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
   configuration                        = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
   key_protect_key                      = var.kms_key_crn

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -523,7 +523,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 189
+        "line": 190
       }
     },
     "ibm_resource_tag.enterprisedb_tag": {
@@ -539,7 +539,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 140
+        "line": 141
       }
     },
     "time_sleep.wait_for_authorization_policy": {
@@ -571,7 +571,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 217
+        "line": 218
       }
     }
   },
@@ -650,7 +650,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 150
+        "line": 151
       }
     }
   }


### PR DESCRIPTION


### Description


jsonencode sets null for any optional value that is not set. postgresql API doesn't like that. We need to remove null versions. 

https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
