### PR TITLE
fix: endpoint_type check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,7 @@ locals {
 
 data "ibm_database_connection" "database_connection" {
   count         = length(var.users) > 0 ? 1 : 0
-  endpoint_type = var.service_endpoints
+  endpoint_type = var.service_endpoints == "public-and-private" ? "public" : var.service_endpoints
   deployment_id = ibm_database.enterprise_db.id
   user_id       = var.users[0].name
   user_type     = var.users[0].type


### PR DESCRIPTION
### Description

An error occurs when endpoint_type is set to "public-and-private". A check has been added to ensure that it isn't set to that. It defaults to public if service_endpoints is "public-and-private".

Related issue: https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/84

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
